### PR TITLE
修复打印容器内实例错误

### DIFF
--- a/pkg/kernel/container/container.go
+++ b/pkg/kernel/container/container.go
@@ -126,23 +126,23 @@ func (p *Container) String() string {
 	lines = append(lines, "singletons:")
 	for name, item := range p.singletons {
 		if item == nil {
-			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
+			line := fmt.Sprintf("  %s: %s %s", name, "<nil>", "<nil>")
 			lines = append(lines, line)
 			continue
 		}
 
-		line := fmt.Sprintf("  %s: %v %s", name, &item, reflect.TypeOf(item).String())
+		line := fmt.Sprintf("  %s: %p %s", name, &item, reflect.TypeOf(item).String())
 		lines = append(lines, line)
 	}
 	lines = append(lines, "factories:")
 	for name, item := range p.factories {
 		if item == nil {
-			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
+			line := fmt.Sprintf("  %s: %s %s", name, "<nil>", "<nil>")
 			lines = append(lines, line)
 			continue
 		}
 
-		line := fmt.Sprintf("  %s: %v %s", name, &item, reflect.TypeOf(item).String())
+		line := fmt.Sprintf("  %s: %p %s", name, &item, reflect.TypeOf(item).String())
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")

--- a/pkg/kernel/container/container.go
+++ b/pkg/kernel/container/container.go
@@ -122,16 +122,28 @@ func (p *Container) isPrototype(tag string) bool {
 
 // 打印容器内部实例
 func (p *Container) String() string {
-    lines := make([]string, 0, len(p.singletons)+len(p.factories)+2)
-    lines = append(lines, "singletons:")
-    for name, item := range p.singletons {
-        line := fmt.Sprintf("  %s: %x %s", name, &item, reflect.TypeOf(item).String())
-        lines = append(lines, line)
-    }
-    lines = append(lines, "factories:")
-    for name, item := range p.factories {
-        line := fmt.Sprintf("  %s: %x %s", name, &item, reflect.TypeOf(item).String())
-        lines = append(lines, line)
-    }
-    return strings.Join(lines, "\n")
+	lines := make([]string, 0, len(p.singletons)+len(p.factories)+2)
+	lines = append(lines, "singletons:")
+	for name, item := range p.singletons {
+		if item ==nil {
+			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
+			lines = append(lines, line)
+			continue
+		}
+
+		line := fmt.Sprintf("  %s: %v %s", name, &item, reflect.TypeOf(item).String())
+		lines = append(lines, line)
+	}
+	lines = append(lines, "factories:")
+	for name, item := range p.factories {
+		if item ==nil {
+			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
+			lines = append(lines, line)
+			continue
+		}
+
+		line := fmt.Sprintf("  %s: %v %s", name, &item, reflect.TypeOf(item).String())
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/pkg/kernel/container/container.go
+++ b/pkg/kernel/container/container.go
@@ -125,7 +125,7 @@ func (p *Container) String() string {
 	lines := make([]string, 0, len(p.singletons)+len(p.factories)+2)
 	lines = append(lines, "singletons:")
 	for name, item := range p.singletons {
-		if item ==nil {
+		if item == nil {
 			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
 			lines = append(lines, line)
 			continue
@@ -136,7 +136,7 @@ func (p *Container) String() string {
 	}
 	lines = append(lines, "factories:")
 	for name, item := range p.factories {
-		if item ==nil {
+		if item == nil {
 			line := fmt.Sprintf("  %s: %v %s", name, "<nil>", "<nil>")
 			lines = append(lines, line)
 			continue


### PR DESCRIPTION
按照原来的写法，如果传入的实例为 nil 会报 panic，并且使用 `%x` 进行输出无法看到正确的地址。